### PR TITLE
Add safe area support for mobile menu button

### DIFF
--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -45,13 +45,7 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
   return (
     <>
       {/* Mobile menu button */}
-      <div
-        className="lg:hidden fixed z-50"
-        style={{
-          top: `max(env(safe-area-inset-top, 16px) + 16px, 60px)`,
-          left: `max(env(safe-area-inset-left, 16px) + 16px, 24px)`,
-        }}
-      >
+      <div className="lg:hidden mobile-menu-button">
         <Button
           variant="outline"
           size="icon"

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -45,7 +45,13 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
   return (
     <>
       {/* Mobile menu button */}
-      <div className="lg:hidden fixed top-4 left-4 z-50">
+      <div
+        className="lg:hidden fixed z-50"
+        style={{
+          top: `max(env(safe-area-inset-top, 16px) + 16px, 60px)`,
+          left: `max(env(safe-area-inset-left, 16px) + 16px, 24px)`,
+        }}
+      >
         <Button
           variant="outline"
           size="icon"

--- a/client/global.css
+++ b/client/global.css
@@ -557,6 +557,21 @@
   }
 }
 
+/* Mobile Menu Button Safe Area */
+.mobile-menu-button {
+  position: fixed;
+  z-index: 50;
+  top: max(env(safe-area-inset-top, 16px) + 16px, 60px);
+  left: max(env(safe-area-inset-left, 16px) + 16px, 24px);
+}
+
+@supports not (env(safe-area-inset-top)) {
+  .mobile-menu-button {
+    top: 60px;
+    left: 24px;
+  }
+}
+
 /* Print Styles */
 @media print {
   .no-print {


### PR DESCRIPTION
Replace inline positioning styles with CSS class for mobile menu button.

Changes:
- Replace `fixed top-4 left-4 z-50` classes with `mobile-menu-button` class in Sidebar.tsx
- Add `.mobile-menu-button` CSS class with safe area inset support
- Use `env(safe-area-inset-top)` and `env(safe-area-inset-left)` for proper positioning on devices with notches/rounded corners
- Include fallback positioning for browsers that don't support safe area insets

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/65a189c6cdba49799afa23773d70ade9/curry-lab)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>65a189c6cdba49799afa23773d70ade9</projectId>-->
<!--<branchName>curry-lab</branchName>-->