### PR TITLE
Add version 2.0.1 to PWA manifest and icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,11 @@
     <meta name="msapplication-tap-highlight" content="no" />
 
     <!-- PWA Manifest -->
-    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
+    <link
+      rel="manifest"
+      href="/manifest.json?v=2.0.1"
+      crossorigin="use-credentials"
+    />
 
     <!-- Apple Touch Icons com logo da Leirisonda -->
     <link
@@ -53,7 +57,7 @@
     />
 
     <!-- Ícone PNG otimizado para iPhone -->
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=2.0.1" />
 
     <!-- Favicon e ícones adicionais -->
     <link rel="icon" href="/favicon.ico" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,8 @@
   "orientation": "portrait-primary",
   "scope": "/",
   "prefer_related_applications": false,
-  "id": "leirisonda-obras-2025",
+  "id": "leirisonda-obras-2025-v2",
+  "version": "2.0.1",
   "icons": [
     {
       "src": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzIiIGhlaWdodD0iNzIiIHZpZXdCb3g9IjAgMCA3MiA3MiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjcyIiBoZWlnaHQ9IjcyIiByeD0iMTYiIGZpbGw9IiNiMzAyMjkiLz4KPHN2ZyB4PSIxNiIgeT0iMTYiIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNMyAxOGgxOHYtMkg5VjhIOXYzSDZ2M0gzVjE4Wm0wIDBoMTh2LTJIOVY4SDl2M0g2djNIM1YxOFoiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik05IDhoMnYySDlWOFptNiAwaDJ2MkgxNlY4WiIgZmlsbD0iIzAwNzc4NCIvPgo8cGF0aCBkPSJNNiAxNGgzdjNINnYtM1ptNiAwaDN2M0gxMnYtM1ptNiAwaDN2M0gxOHYtM1oiIGZpbGw9IiMwMDc3ODQiIG9wYWNpdHk9IjAuNyIvPgo8L3N2Zz4KPC9zdmc+",


### PR DESCRIPTION
Updates PWA configuration with version 2.0.1:

- Add version query parameter to manifest.json link in index.html
- Add version query parameter to apple-touch-icon link in index.html
- Update PWA manifest ID from "leirisonda-obras-2025" to "leirisonda-obras-2025-v2"
- Add "version": "2.0.1" field to manifest.json

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/65a189c6cdba49799afa23773d70ade9/aura-studio)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>65a189c6cdba49799afa23773d70ade9</projectId>-->
<!--<branchName>aura-studio</branchName>-->