### PR TITLE
Replace external logo URL with local apple-touch-icon

### DIFF
--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -57,7 +57,7 @@ export function Login() {
             <div className="relative z-10">
               <div className="mx-auto w-24 h-24 bg-white rounded-2xl flex items-center justify-center mb-6 shadow-lg p-3">
                 <img
-                  src="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2F9862202d056a426996e6178b9981c1c7?format=webp&width=800"
+                  src="/apple-touch-icon.png"
                   alt="Leirisonda Logo"
                   className="w-16 h-16 object-contain"
                 />


### PR DESCRIPTION
Updates the logo image source in the Login component from an external Builder.io CDN URL to a local apple-touch-icon.png file.

Changes:
- Modified src attribute in Login.tsx from Builder.io CDN URL to "/apple-touch-icon.png"
- Maintains existing alt text "Leirisonda Logo" and styling classes

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/65a189c6cdba49799afa23773d70ade9/echo-zone)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>65a189c6cdba49799afa23773d70ade9</projectId>-->
<!--<branchName>echo-zone</branchName>-->