### PR TITLE
Remove alimenta field from maintenance system

### DIFF
--- a/client/components/MaintenanceReport.tsx
+++ b/client/components/MaintenanceReport.tsx
@@ -249,7 +249,7 @@ ${maintenance.observations}
     : ""
 }
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━���━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 📞 CONTACTO
 Leirisonda - Manutenção de Piscinas
@@ -1234,7 +1234,6 @@ Relatório gerado em: ${reportDate}
       filtros: "Limpeza de Filtros",
       preFiltero: "Pré-filtro",
       filtroAreiaVidro: "Filtro Areia/Vidro",
-      alimenta: "Sistema de Alimentação",
       enchimentoAutomatico: "Enchimento Automático",
       linhaAgua: "Linha de Água",
       limpezaFundo: "Limpeza do Fundo",

--- a/client/pages/CreateIntervention.tsx
+++ b/client/pages/CreateIntervention.tsx
@@ -59,7 +59,6 @@ export function CreateIntervention() {
       filtros: false,
       preFiltro: false,
       filtroAreiaVidro: false,
-      alimenta: false,
       enchimentoAutomatico: false,
       linhaAgua: false,
       limpezaFundo: false,

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -57,7 +57,7 @@ export function Login() {
             <div className="relative z-10">
               <div className="mx-auto w-32 h-32 bg-white rounded-3xl flex items-center justify-center mb-6 shadow-xl p-4">
                 <img
-                  src="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2Fb4eb4a9e6feb44b09201dbb824b8737c?format=webp&width=800"
+                  src="/leirisonda-logo-complete.svg"
                   alt="Leirisonda Logo"
                   className="w-full h-full object-contain"
                 />

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -57,7 +57,7 @@ export function Login() {
             <div className="relative z-10">
               <div className="mx-auto w-32 h-32 bg-white rounded-3xl flex items-center justify-center mb-6 shadow-xl p-4">
                 <img
-                  src="/leirisonda-logo-complete.svg"
+                  src="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2Fb4eb4a9e6feb44b09201dbb824b8737c?format=webp&width=800"
                   alt="Leirisonda Logo"
                   className="w-full h-full object-contain"
                 />

--- a/client/pages/PoolMaintenance.tsx
+++ b/client/pages/PoolMaintenance.tsx
@@ -54,7 +54,6 @@ export function PoolMaintenancePage() {
       filtros: false,
       preFiltro: false,
       filtroAreiaVidro: false,
-      alimenta: false,
       enchimentoAutomatico: false,
       linhaAgua: false,
       outros: "",
@@ -642,18 +641,7 @@ export function PoolMaintenancePage() {
                     ⚙️ Sistemas da Piscina
                   </h4>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3 ml-4">
-                    <div className="flex items-center space-x-3">
-                      <Checkbox
-                        id="alimenta"
-                        checked={formData.maintenanceWork.alimenta}
-                        onCheckedChange={(checked) =>
-                          updateFormData("maintenanceWork.alimenta", checked)
-                        }
-                      />
-                      <Label htmlFor="alimenta" className="text-sm">
-                        Alimentação/Dosagem
-                      </Label>
-                    </div>
+
 
                     <div className="flex items-center space-x-3">
                       <Checkbox
@@ -889,10 +877,6 @@ export function PoolMaintenancePage() {
                       Sistemas da Piscina
                     </h6>
                     <div className="flex flex-wrap gap-2">
-                      {maintenance.maintenanceWork.alimenta && (
-                        <span className="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full">
-                          ✓ Alimentação/Dosagem
-                        </span>
                       )}
                       {maintenance.maintenanceWork.enchimentoAutomatico && (
                         <span className="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full">

--- a/client/pages/PoolMaintenance.tsx
+++ b/client/pages/PoolMaintenance.tsx
@@ -641,8 +641,6 @@ export function PoolMaintenancePage() {
                     ⚙️ Sistemas da Piscina
                   </h4>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3 ml-4">
-
-
                     <div className="flex items-center space-x-3">
                       <Checkbox
                         id="enchimentoAutomatico"
@@ -877,7 +875,6 @@ export function PoolMaintenancePage() {
                       Sistemas da Piscina
                     </h6>
                     <div className="flex flex-wrap gap-2">
-                      )}
                       {maintenance.maintenanceWork.enchimentoAutomatico && (
                         <span className="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full">
                           ✓ Enchimento Automático

--- a/client/services/DefaultData.ts
+++ b/client/services/DefaultData.ts
@@ -187,7 +187,6 @@ export class DefaultDataService {
                 filtros: true,
                 preFiltro: true,
                 filtroAreiaVidro: false,
-                alimenta: true,
                 enchimentoAutomatico: false,
                 linhaAgua: true,
                 limpezaFundo: true,

--- a/index.html
+++ b/index.html
@@ -35,13 +35,29 @@
     />
 
     <!-- Apple Touch Icons otimizados para iPhone com logo Leirisonda -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/leirisonda-icon.svg" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/leirisonda-icon.svg" />
-    <link rel="apple-touch-icon" sizes="120x120" href="/leirisonda-icon.svg" />
-    <link rel="apple-touch-icon" sizes="76x76" href="/leirisonda-icon.svg" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/apple-touch-icon-180x180.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="152x152"
+      href="/apple-touch-icon-180x180.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="120x120"
+      href="/apple-touch-icon-180x180.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="76x76"
+      href="/apple-touch-icon-180x180.png"
+    />
 
     <!-- Ícone principal para iPhone com logotipo completo da Leirisonda -->
-    <link rel="apple-touch-icon" href="/leirisonda-icon.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
     <!-- Favicon e ícones adicionais com logo da Leirisonda -->
     <link rel="icon" href="/favicon.ico" />

--- a/index.html
+++ b/index.html
@@ -35,32 +35,13 @@
     />
 
     <!-- Apple Touch Icons otimizados para iPhone com logo Leirisonda -->
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2Fb4eb4a9e6feb44b09201dbb824b8737c?format=png&width=180"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="152x152"
-      href="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2Fb4eb4a9e6feb44b09201dbb824b8737c?format=png&width=152"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="120x120"
-      href="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2Fb4eb4a9e6feb44b09201dbb824b8737c?format=png&width=120"
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="76x76"
-      href="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2Fb4eb4a9e6feb44b09201dbb824b8737c?format=png&width=76"
-    />
+    <link rel="apple-touch-icon" sizes="180x180" href="/leirisonda-icon.svg" />
+    <link rel="apple-touch-icon" sizes="152x152" href="/leirisonda-icon.svg" />
+    <link rel="apple-touch-icon" sizes="120x120" href="/leirisonda-icon.svg" />
+    <link rel="apple-touch-icon" sizes="76x76" href="/leirisonda-icon.svg" />
 
     <!-- Ícone principal para iPhone com logotipo completo da Leirisonda -->
-    <link
-      rel="apple-touch-icon"
-      href="https://cdn.builder.io/api/v1/image/assets%2F24b5ff5dbb9f4bb493659e90291d92bc%2Fb4eb4a9e6feb44b09201dbb824b8737c?format=png&width=180"
-    />
+    <link rel="apple-touch-icon" href="/leirisonda-icon.svg" />
 
     <!-- Favicon e ícones adicionais com logo da Leirisonda -->
     <link rel="icon" href="/favicon.ico" />

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -116,7 +116,6 @@ export interface MaintenanceIntervention {
     filtros: boolean;
     preFiltro: boolean;
     filtroAreiaVidro: boolean;
-    alimenta: boolean;
     enchimentoAutomatico: boolean;
     linhaAgua: boolean;
     limpezaFundo: boolean;


### PR DESCRIPTION
Remove the "alimenta" (feeding/dosing system) field from the maintenance work interface and related components.

Changes made:
- Remove alimenta field from MaintenanceIntervention type definition
- Remove alimenta checkbox from PoolMaintenance form
- Remove alimenta from CreateIntervention initial state
- Remove alimenta from maintenance report display
- Remove alimenta from DefaultDataService configuration
- Update MaintenanceReport template labels
- Replace external CDN icon URLs with local file paths in index.html

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/65a189c6cdba49799afa23773d70ade9/vibe-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>65a189c6cdba49799afa23773d70ade9</projectId>-->
<!--<branchName>vibe-oasis</branchName>-->