### PR TITLE
Update volume units from litros to m³ and add back button

### DIFF
--- a/client/components/MaintenanceReport.tsx
+++ b/client/components/MaintenanceReport.tsx
@@ -199,7 +199,7 @@ export function MaintenanceReport({
                 ? `
             <tr>
               <td class="table-label">Volume:</td>
-              <td class="table-value">${maintenance.waterCubicage} litros</td>
+              <td class="table-value">${maintenance.waterCubicage} m³</td>
             </tr>`
                 : ""
             }

--- a/client/components/MaintenanceReport.tsx
+++ b/client/components/MaintenanceReport.tsx
@@ -615,7 +615,7 @@ export function MaintenanceReport({
                 ? `
             <tr>
               <td class="table-label">Volume:</td>
-              <td class="table-value">${maintenance.waterCubicage} litros</td>
+              <td class="table-value">${maintenance.waterCubicage} m³</td>
             </tr>`
                 : ""
             }

--- a/client/components/MaintenanceReport.tsx
+++ b/client/components/MaintenanceReport.tsx
@@ -911,7 +911,7 @@ export function MaintenanceReport({
         date: intervention
           ? format(new Date(intervention.date), "dd/MM/yyyy", { locale: pt })
           : new Date().toLocaleDateString("pt-PT"),
-        additionalInfo: `Cliente: ${maintenance.clientName} • Tipo: ${getPoolTypeLabel(maintenance.poolType)} • Volume: ${maintenance.waterCubicage || "N/A"} litros`,
+        additionalInfo: `Cliente: ${maintenance.clientName} • Tipo: ${getPoolTypeLabel(maintenance.poolType)} • Volume: ${maintenance.waterCubicage || "N/A"} m³`,
       };
 
       const htmlContent = PDFGenerator.createModernReportHTML({

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -62,6 +62,25 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
         </Button>
       </div>
 
+      {/* Back button - positioned below menu button */}
+      <div
+        className="lg:hidden fixed z-50"
+        style={{
+          top: "max(env(safe-area-inset-top, 16px) + 76px, 116px)",
+          left: "max(env(safe-area-inset-left, 16px) + 16px, 24px)",
+        }}
+      >
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handleGoBack}
+          className="bg-white shadow-lg hover-leirisonda"
+          title="Voltar à página anterior"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+      </div>
+
       {/* Backdrop */}
       {isOpen && (
         <div

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -37,10 +37,15 @@ const adminNavigation = [
 
 export function Sidebar({ isOpen, onToggle }: SidebarProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const { user, logout } = useAuth();
 
   const handleLogout = () => {
     logout();
+  };
+
+  const handleGoBack = () => {
+    navigate(-1);
   };
 
   return (

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -117,6 +117,16 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
 
           {/* Navigation */}
           <nav className="flex-1 p-4 space-y-2">
+            {/* Back button for desktop */}
+            <button
+              onClick={handleGoBack}
+              className="nav-item-leirisonda mb-4"
+              title="Voltar à página anterior"
+            >
+              <ArrowLeft className="mr-3 h-5 w-5" />
+              Voltar
+            </button>
+
             {navigation.map((item) => {
               const Icon = item.icon;
               const isActive =

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   Home,
   Briefcase,
@@ -14,6 +14,7 @@ import {
   Activity,
   Building,
   Wrench,
+  ArrowLeft,
 } from "lucide-react";
 import { useAuth } from "./AuthProvider";
 import { Button } from "./ui/button";

--- a/client/components/Sidebar.tsx
+++ b/client/components/Sidebar.tsx
@@ -44,7 +44,9 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
     logout();
   };
 
-  const handleGoBack = () => {
+  const handleGoBack = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     navigate(-1);
   };
 

--- a/client/pages/CreateMaintenance.tsx
+++ b/client/pages/CreateMaintenance.tsx
@@ -241,7 +241,7 @@ export function CreateMaintenance() {
                 <Input
                   id="waterCubicage"
                   type="text"
-                  placeholder="Ex: 50m³ ou 50000L"
+                  placeholder="Ex: 50m³"
                   value={formData.waterCubicage}
                   onChange={(e) =>
                     handleInputChange("waterCubicage", e.target.value)

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -20,9 +20,7 @@ import {
 import { Work, DashboardStats } from "@shared/types";
 import { useAuth } from "@/components/AuthProvider";
 import { Button } from "@/components/ui/button";
-import { SyncStatus } from "@/components/SyncStatus";
 import { useFirebaseSync } from "@/hooks/use-firebase-sync";
-import { FirebaseStatus } from "@/components/FirebaseStatus";
 import { format } from "date-fns";
 import { pt } from "date-fns/locale";
 

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -210,8 +210,6 @@ export function Dashboard() {
         </div>
       </div>
 
-      {/* Firebase Sync Status */}
-      <FirebaseStatus />
       {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6">
         <div

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -461,13 +461,12 @@ export function Dashboard() {
 
             <div className="space-y-4">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
                 <input
                   type="text"
                   placeholder="Cliente, folha obra, morada..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="input-leirisonda pl-10 text-sm"
+                  className="input-leirisonda text-sm"
                 />
               </div>
 

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -62,7 +62,7 @@ export function Login() {
                   className="w-full h-full object-contain"
                 />
               </div>
-              <h1 className="text-2xl font-bold mb-2">Leirisonda</h1>
+              <h1 className="text-2xl font-bold mb-2 text-white">Leirisonda</h1>
               <p className="text-blue-100 opacity-90">
                 Sistema de Gestão de Obras
               </p>


### PR DESCRIPTION
This pull request makes several UI improvements:

**Volume Unit Changes:**
- Changed volume display from "litros" to "m³" in MaintenanceReport component
- Updated placeholder text in CreateMaintenance from "Ex: 50m³ ou 50000L" to "Ex: 50m³"

**Navigation Improvements:**
- Added back button functionality to Sidebar component
- Imported ArrowLeft icon and useNavigate hook
- Added back button for both mobile and desktop views with proper positioning

**UI Cleanup:**
- Removed FirebaseStatus component from Dashboard
- Removed search icon from search input field in Dashboard
- Added white text color to "Leirisonda" heading in Login component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 26`

🔗 [Edit in Builder.io](https://builder.io/app/projects/65a189c6cdba49799afa23773d70ade9/flare-world)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>65a189c6cdba49799afa23773d70ade9</projectId>-->
<!--<branchName>flare-world</branchName>-->