### PR TITLE
Limit notifications to current assigned user only

### DIFF
--- a/client/services/NotificationService.ts
+++ b/client/services/NotificationService.ts
@@ -262,15 +262,47 @@ class NotificationServiceClass {
     });
 
     try {
-      // Obter tokens dos usuários atribuídos
-      const userTokens = JSON.parse(
-        localStorage.getItem("userNotificationTokens") || "{}",
+      // Verificar usuário atual para mostrar notificação apenas se estiver atribuído
+      const currentUser = JSON.parse(
+        localStorage.getItem("leirisonda_user") || "{}",
       );
 
-      // Buscar usuários de múltiplas fontes
-      const storedUsers = JSON.parse(localStorage.getItem("users") || "[]");
+      console.log("👤 Usuário atual:", {
+        currentUserId: currentUser.id,
+        currentUserName: currentUser.name,
+        assignedUsers: assignedUsers,
+        shouldReceiveNotification: assignedUsers.includes(currentUser.id),
+      });
 
-      // Usuários globais predefinidos
+      // Só mostrar notificação LOCAL se o usuário atual estiver entre os atribuídos
+      if (currentUser.id && assignedUsers.includes(currentUser.id)) {
+        const payload: NotificationPayload = {
+          title: "🏗️ Nova Obra Atribuída",
+          body: `Foi-lhe atribuída a obra ${work.workSheetNumber} - ${work.clientName}`,
+          data: {
+            type: "work_assigned",
+            workId: work.id,
+            workSheetNumber: work.workSheetNumber,
+            clientName: work.clientName,
+          },
+          icon: "/leirisonda-icon.svg",
+        };
+
+        console.log(
+          `📨 Mostrando notificação local para ${currentUser.name}...`,
+        );
+        await this.showLocalNotification(payload);
+        console.log(
+          `✅ Notificação exibida para ${currentUser.name} (${currentUser.email})`,
+        );
+      } else {
+        console.log(
+          `ℹ️ Usuário atual (${currentUser.name || "Desconhecido"}) não está entre os atribuídos - não mostrar notificação local`,
+        );
+      }
+
+      // Log para todos os usuários atribuídos (para debug/auditoria)
+      const storedUsers = JSON.parse(localStorage.getItem("users") || "[]");
       const globalUsers = [
         {
           id: "admin_goncalo",
@@ -286,57 +318,14 @@ class NotificationServiceClass {
         },
       ];
 
-      // Combinar ambas as listas
       const allUsers = [...storedUsers, ...globalUsers];
 
-      console.log("👥 Usuários disponíveis para notificação:", {
-        stored: storedUsers.length,
-        global: globalUsers.length,
-        total: allUsers.length,
-        tokens: Object.keys(userTokens),
-        assignedUsers,
-      });
-
+      console.log("📋 Auditoria de notificações:");
       for (const userId of assignedUsers) {
         const user = allUsers.find((u: User) => u.id === userId);
-        const token = userTokens[userId];
-
-        console.log(`🔍 Verificando usuário ${userId}:`, {
-          userFound: !!user,
-          userName: user?.name,
-          userEmail: user?.email,
-          hasToken: !!token,
-        });
-
         if (user) {
-          const payload: NotificationPayload = {
-            title: "🏗️ Nova Obra Atribuída",
-            body: `Foi-lhe atribuída a obra ${work.workSheetNumber} - ${work.clientName}`,
-            data: {
-              type: "work_assigned",
-              workId: work.id,
-              workSheetNumber: work.workSheetNumber,
-              clientName: work.clientName,
-            },
-            icon: "/leirisonda-icon.svg",
-          };
-
-          // Mostrar notificação local SEMPRE, mesmo sem token FCM
-          console.log(`📨 Enviando notificação local para ${user.name}...`);
-          await this.showLocalNotification(payload);
-
-          // Se tem token FCM, poderia enviar via servidor
-          if (token) {
-            // await this.sendPushNotification(token, payload);
-            console.log(`🔑 Token FCM disponível para ${user.name}`);
-          } else {
-            console.log(
-              `⚠️ Sem token FCM para ${user.name}, apenas notificação local`,
-            );
-          }
-
           console.log(
-            `✅ Notificação enviada para ${user.name} (${user.email})`,
+            `👤 ${user.name} (${user.email}) - deve receber notificação quando acessar o sistema`,
           );
         }
       }
@@ -430,7 +419,7 @@ class NotificationServiceClass {
     payload: NotificationPayload,
   ) {
     // Implementar envio via servidor FCM
-    // Esta funcionalidade requer um servidor backend para enviar as notificações
+    // Esta funcionalidade requer um servidor backend para enviar as notificaç��es
     console.log("📤 Enviaria notificação push para token:", token, payload);
   }
 

--- a/client/services/NotificationService.ts
+++ b/client/services/NotificationService.ts
@@ -342,17 +342,57 @@ class NotificationServiceClass {
     console.log("🔄 Enviando notificação de mudança de status:", {
       work: work.workSheetNumber,
       status: newStatus,
+      assignedUsers: assignedUsers,
     });
 
     try {
-      const userTokens = JSON.parse(
-        localStorage.getItem("userNotificationTokens") || "{}",
+      // Verificar usuário atual para mostrar notificação apenas se estiver atribuído
+      const currentUser = JSON.parse(
+        localStorage.getItem("leirisonda_user") || "{}",
       );
 
-      // Buscar usuários de múltiplas fontes
-      const storedUsers = JSON.parse(localStorage.getItem("users") || "[]");
+      console.log("👤 Usuário atual para status change:", {
+        currentUserId: currentUser.id,
+        currentUserName: currentUser.name,
+        assignedUsers: assignedUsers,
+        shouldReceiveNotification: assignedUsers.includes(currentUser.id),
+      });
 
-      // Usuários globais predefinidos
+      // Só mostrar notificação LOCAL se o usuário atual estiver entre os atribuídos
+      if (currentUser.id && assignedUsers.includes(currentUser.id)) {
+        const statusLabels = {
+          pendente: "Pendente",
+          em_progresso: "Em Progresso",
+          concluida: "Concluída",
+        };
+
+        const payload: NotificationPayload = {
+          title: "📋 Status da Obra Atualizado",
+          body: `Obra ${work.workSheetNumber} agora está: ${statusLabels[newStatus as keyof typeof statusLabels]}`,
+          data: {
+            type: "work_status_change",
+            workId: work.id,
+            workSheetNumber: work.workSheetNumber,
+            newStatus,
+          },
+          icon: "/leirisonda-icon.svg",
+        };
+
+        console.log(
+          `📨 Mostrando notificação de status para ${currentUser.name}...`,
+        );
+        await this.showLocalNotification(payload);
+        console.log(
+          `✅ Notificação de status exibida para ${currentUser.name} (${currentUser.email})`,
+        );
+      } else {
+        console.log(
+          `ℹ️ Usuário atual (${currentUser.name || "Desconhecido"}) não está entre os atribuídos - não mostrar notificação de status`,
+        );
+      }
+
+      // Log para auditoria
+      const storedUsers = JSON.parse(localStorage.getItem("users") || "[]");
       const globalUsers = [
         {
           id: "admin_goncalo",
@@ -368,41 +408,15 @@ class NotificationServiceClass {
         },
       ];
 
-      // Combinar ambas as listas
       const allUsers = [...storedUsers, ...globalUsers];
 
-      const statusLabels = {
-        pendente: "Pendente",
-        em_progresso: "Em Progresso",
-        concluida: "Concluída",
-      };
-
+      console.log("📋 Auditoria de notificações de status:");
       for (const userId of assignedUsers) {
         const user = allUsers.find((u: User) => u.id === userId);
-        const token = userTokens[userId];
-
-        console.log(`🔍 Verificando usuário ${userId} para status change:`, {
-          userFound: !!user,
-          userName: user?.name,
-          hasToken: !!token,
-        });
-
         if (user) {
-          const payload: NotificationPayload = {
-            title: "📋 Status da Obra Atualizado",
-            body: `Obra ${work.workSheetNumber} agora está: ${statusLabels[newStatus as keyof typeof statusLabels]}`,
-            data: {
-              type: "work_status_change",
-              workId: work.id,
-              workSheetNumber: work.workSheetNumber,
-              newStatus,
-            },
-            icon: "/leirisonda-icon.svg",
-          };
-
-          // Mostrar notificação local SEMPRE, mesmo sem token FCM
-          await this.showLocalNotification(payload);
-          console.log(`✅ Notificação de status enviada para ${user.name}`);
+          console.log(
+            `👤 ${user.name} (${user.email}) - deve receber notificação de status quando acessar o sistema`,
+          );
         }
       }
     } catch (error) {
@@ -419,7 +433,7 @@ class NotificationServiceClass {
     payload: NotificationPayload,
   ) {
     // Implementar envio via servidor FCM
-    // Esta funcionalidade requer um servidor backend para enviar as notificaç��es
+    // Esta funcionalidade requer um servidor backend para enviar as notificações
     console.log("📤 Enviaria notificação push para token:", token, payload);
   }
 


### PR DESCRIPTION
Changes notification behavior to only show local notifications to the currently logged-in user if they are among the assigned users for a work item.

Key changes:
- Added current user check before showing local notifications
- Only displays notifications if current user ID is in the assigned users list
- Replaced individual user notification loops with single current user check
- Updated logging to show audit information for all assigned users
- Applied changes to both work assignment and status change notifications
- Removed FCM token handling and individual user iteration logic

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 72`

🔗 [Edit in Builder.io](https://builder.io/app/projects/65a189c6cdba49799afa23773d70ade9/zenith-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>65a189c6cdba49799afa23773d70ade9</projectId>-->
<!--<branchName>zenith-hub</branchName>-->