### PR TITLE
Update mobile menu position and CSS color variables

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4745,7 +4745,7 @@ ${index + 1}. ${maint.poolName} - ${maint.type}
       </div>
 
       {/* Mobile Menu Button */}
-      <div className="lg:hidden fixed top-4 left-4 z-60 flex flex-col space-y-2">
+      <div className="lg:hidden fixed top-20 left-4 z-60 flex flex-col space-y-2">
         <button
           onClick={() => setSidebarOpen(!sidebarOpen)}
           className="bg-white p-2 rounded-md shadow-md"

--- a/src/index.css
+++ b/src/index.css
@@ -4,9 +4,53 @@
 
 @layer base {
   :root {
-    --leirisonda-primary: #007784;
-    --leirisonda-secondary: #61a5d6;
-    --leirisonda-dark: #004d54;
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96%;
+    --secondary-foreground: 222.2 84% 4.9%;
+    --muted: 210 40% 96%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96%;
+    --accent-foreground: 222.2 84% 4.9%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+    --leirisonda-primary: 189 100% 27%;
+    --leirisonda-secondary: 207 54% 62%;
+    --leirisonda-footer: 189 100% 16%;
+    --leirisonda-blue-light: 207 54% 82%;
+    --leirisonda-header-blue: 207 54% 52%;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
   }
 }
 


### PR DESCRIPTION
This pull request makes two main changes:

1. **Mobile menu positioning**: Moved the mobile menu button from `top-4` to `top-20` in App.tsx to adjust its vertical position on the screen.

2. **CSS color system overhaul**: Replaced the existing Leirisonda color variables with a comprehensive design system that includes:
   - Standard UI colors (background, foreground, card, popover, etc.)
   - Primary, secondary, muted, and accent color variants
   - Dark mode support with corresponding color definitions
   - Updated Leirisonda brand colors with HSL values
   - Added new color variables for footer, light blue, and header blue

The changes maintain the existing Leirisonda brand colors while introducing a more robust color system that supports both light and dark themes.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 102`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f1ebb0dfdb74604acc78e947ecfe3bf/spark-den)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f1ebb0dfdb74604acc78e947ecfe3bf</projectId>-->
<!--<branchName>spark-den</branchName>-->