### PR TITLE
Add clients and interventions to data cleanup system

### DIFF
--- a/src/components/DataCleanupManager.tsx
+++ b/src/components/DataCleanupManager.tsx
@@ -254,7 +254,7 @@ export function DataCleanupManager({
                 <div className="text-sm font-medium text-gray-700 mb-2">
                   Firestore (Eliminações)
                 </div>
-                <div className="grid grid-cols-3 gap-4 text-sm">
+                <div className="grid grid-cols-2 gap-4 text-sm">
                   <div>
                     Piscinas: {lastResult.details.firestoreDeleted.pools}
                   </div>
@@ -262,6 +262,13 @@ export function DataCleanupManager({
                   <div>
                     Manutenções:{" "}
                     {lastResult.details.firestoreDeleted.maintenance}
+                  </div>
+                  <div>
+                    Clientes: {lastResult.details.firestoreDeleted.clients}
+                  </div>
+                  <div>
+                    Intervenções:{" "}
+                    {lastResult.details.firestoreDeleted.interventions}
                   </div>
                 </div>
               </div>

--- a/src/firebase/config.ts
+++ b/src/firebase/config.ts
@@ -6,6 +6,8 @@ import { getAuth } from "firebase/auth";
 const defaultFirebaseConfig = {
   apiKey: "AIzaSyC7BHkdQSdAoTzjM39vm90C9yejcoOPCjE",
   authDomain: "leirisonda-16f8b.firebaseapp.com",
+  databaseURL:
+    "https://leirisonda-16f8b-default-rtdb.europe-west1.firebasedatabase.app",
   projectId: "leirisonda-16f8b",
   storageBucket: "leirisonda-16f8b.firebasestorage.app",
   messagingSenderId: "540456875574",

--- a/src/hooks/useDataCleanup.ts
+++ b/src/hooks/useDataCleanup.ts
@@ -67,7 +67,13 @@ export function useDataCleanup(): UseDataCleanupReturn {
         success: false,
         message: errorMessage,
         details: {
-          firestoreDeleted: { pools: 0, works: 0, maintenance: 0 },
+          firestoreDeleted: {
+            pools: 0,
+            works: 0,
+            maintenance: 0,
+            clients: 0,
+            interventions: 0,
+          },
           realtimeDbCleared: false,
           localStorageCleared: false,
         },

--- a/src/services/dataCleanupService.ts
+++ b/src/services/dataCleanupService.ts
@@ -15,6 +15,8 @@ export interface CleanupResult {
       pools: number;
       works: number;
       maintenance: number;
+      clients: number;
+      interventions: number;
     };
     realtimeDbCleared: boolean;
     localStorageCleared: boolean;
@@ -38,6 +40,8 @@ class DataCleanupService {
           pools: 0,
           works: 0,
           maintenance: 0,
+          clients: 0,
+          interventions: 0,
         },
         realtimeDbCleared: false,
         localStorageCleared: false,
@@ -77,6 +81,7 @@ class DataCleanupService {
           const clientsSnapshot = await getDocs(collection(db, "clients"));
           for (const clientDoc of clientsSnapshot.docs) {
             await deleteDoc(doc(db, "clients", clientDoc.id));
+            result.details.firestoreDeleted.clients++;
           }
           console.log(
             `Deleted ${clientsSnapshot.docs.length} clients from Firestore`,
@@ -92,6 +97,7 @@ class DataCleanupService {
           );
           for (const interventionDoc of interventionsSnapshot.docs) {
             await deleteDoc(doc(db, "interventions", interventionDoc.id));
+            result.details.firestoreDeleted.interventions++;
           }
           console.log(
             `Deleted ${interventionsSnapshot.docs.length} interventions from Firestore`,
@@ -101,7 +107,7 @@ class DataCleanupService {
         }
 
         console.log(
-          `Firestore cleanup complete: ${result.details.firestoreDeleted.pools} pools, ${result.details.firestoreDeleted.works} works, ${result.details.firestoreDeleted.maintenance} maintenance deleted`,
+          `Firestore cleanup complete: ${result.details.firestoreDeleted.pools} pools, ${result.details.firestoreDeleted.works} works, ${result.details.firestoreDeleted.maintenance} maintenance, ${result.details.firestoreDeleted.clients} clients, ${result.details.firestoreDeleted.interventions} interventions deleted`,
         );
       }
 

--- a/src/services/dataCleanupService.ts
+++ b/src/services/dataCleanupService.ts
@@ -212,12 +212,22 @@ class DataCleanupService {
       throw new Error("Realtime Database not initialized");
     }
 
+    console.log("🚀 Fetching all data from Realtime Database...");
+
     // Since realFirebaseService doesn't expose a direct delete all method,
     // we need to get all data and delete individually
     const allData = await realFirebaseService.syncAllData();
 
     if (allData) {
+      console.log(`Found data in Realtime DB:`, {
+        pools: allData.pools.length,
+        works: allData.works.length,
+        maintenance: allData.maintenance.length,
+        clients: allData.clients.length,
+      });
+
       // Delete all pools
+      console.log(`Deleting ${allData.pools.length} pools from Realtime DB...`);
       for (const pool of allData.pools) {
         if (pool.id) {
           await realFirebaseService.deletePool(pool.id);
@@ -225,6 +235,7 @@ class DataCleanupService {
       }
 
       // Delete all works
+      console.log(`Deleting ${allData.works.length} works from Realtime DB...`);
       for (const work of allData.works) {
         if (work.id) {
           await realFirebaseService.deleteWork(work.id);
@@ -232,6 +243,9 @@ class DataCleanupService {
       }
 
       // Delete all maintenance
+      console.log(
+        `Deleting ${allData.maintenance.length} maintenance records from Realtime DB...`,
+      );
       for (const maintenance of allData.maintenance) {
         if (maintenance.id) {
           await realFirebaseService.deleteMaintenance(maintenance.id);
@@ -239,6 +253,9 @@ class DataCleanupService {
       }
 
       // Delete all clients
+      console.log(
+        `Deleting ${allData.clients.length} clients from Realtime DB...`,
+      );
       for (const client of allData.clients) {
         if (client.id) {
           try {
@@ -248,6 +265,8 @@ class DataCleanupService {
           }
         }
       }
+    } else {
+      console.log("No data found in Realtime Database or failed to fetch data");
     }
   }
 

--- a/src/services/realFirebaseService.ts
+++ b/src/services/realFirebaseService.ts
@@ -255,6 +255,35 @@ class RealFirebaseService {
     }
   }
 
+  async updateClient(clientId: string, clientData: any): Promise<boolean> {
+    if (!this.isReady()) return false;
+
+    try {
+      const clientRef = ref(this.database!, `clients/${clientId}`);
+      await update(clientRef, {
+        ...clientData,
+        updatedAt: new Date().toISOString(),
+      });
+      return true;
+    } catch (error) {
+      console.error("Failed to update client:", error);
+      return false;
+    }
+  }
+
+  async deleteClient(clientId: string): Promise<boolean> {
+    if (!this.isReady()) return false;
+
+    try {
+      const clientRef = ref(this.database!, `clients/${clientId}`);
+      await remove(clientRef);
+      return true;
+    } catch (error) {
+      console.error("Failed to delete client:", error);
+      return false;
+    }
+  }
+
   // Real-time listeners
   onPoolsChange(callback: (pools: any[]) => void): () => void {
     if (!this.isReady()) return () => {};

--- a/src/services/realFirebaseService.ts
+++ b/src/services/realFirebaseService.ts
@@ -30,10 +30,6 @@ class RealFirebaseService {
 
   // Initialize Firebase using existing app instance
   initialize(): boolean {
-    // Firebase temporarily paused - running in offline mode
-    console.log("⏸️ Firebase initialization paused - offline mode active");
-    return false;
-
     try {
       if (!firebaseApp) {
         console.error("Firebase app not available from config");


### PR DESCRIPTION
This pull request extends the data cleanup functionality to include clients and interventions data.

Changes made:
- Added clients and interventions fields to CleanupResult interface
- Updated DataCleanupManager UI to display clients and interventions deletion counts in a 2-column grid layout
- Enhanced dataCleanupService to delete clients and interventions from Firestore with error handling
- Added comprehensive logging for all cleanup operations
- Implemented deleteClient method in realFirebaseService
- Updated localStorage cleanup to include clients data validation
- Added databaseURL to Firebase configuration
- Re-enabled Firebase initialization in realFirebaseService

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 124`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f1ebb0dfdb74604acc78e947ecfe3bf/zenith-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f1ebb0dfdb74604acc78e947ecfe3bf</projectId>-->
<!--<branchName>zenith-garden</branchName>-->