### PR TITLE
Add null check for assignedTo in alexandreWorks filter

### DIFF
--- a/src/hooks/useDataSync.ts
+++ b/src/hooks/useDataSync.ts
@@ -544,8 +544,8 @@ export function useDataSync(): SyncState & SyncActions {
       works: finalWorks.length,
       maintenance: finalMaintenance.length,
       clients: finalClients.length,
-      alexandreWorks: finalWorks.filter((w) =>
-        w.assignedTo.includes("Alexandre"),
+      alexandreWorks: finalWorks.filter(
+        (w) => w.assignedTo && w.assignedTo.includes("Alexandre"),
       ).length,
     });
   }, []);


### PR DESCRIPTION
Add null/undefined check for the `assignedTo` property before calling `includes()` method in the alexandreWorks filter.

This prevents potential runtime errors when `assignedTo` is null or undefined by ensuring the property exists before attempting to check if it includes "Alexandre".

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 132`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f1ebb0dfdb74604acc78e947ecfe3bf/echo-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f1ebb0dfdb74604acc78e947ecfe3bf</projectId>-->
<!--<branchName>echo-garden</branchName>-->